### PR TITLE
Local libraries with install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+src
+build/usr

--- a/README.md
+++ b/README.md
@@ -51,13 +51,45 @@ apt install tcl libyaml-0-2
 ```
 
 You also need to install some dependencies and bindings for executing C code in
-Tcl. This is a lot trickier. Hopefully, this short guide below makes it work
-for you.
+Tcl. This is a lot trickier. Hopefully, the included installation script makes
+this work for you. If not, there is also the option to manual install them.
+Below are the intructions on using the installation scipt, followed by the
+alternative manual installation guide.
 
-Prepare a folder to download, build and install some modules. The next sections
-will be executed in that folder.
+#### Installation script
 
-**Install CriTcl**
+There is an `install.tcl` script in the root of this repository. This Tcl
+script will create a `src` and `build` directory inside the repository
+directory. The `src` directory will be used to clone the git repositories, and
+the built sources will be placed in the `build` directory. Make sure to execute
+the installation script whith this repository directory as your working
+directory, like so:
+
+```
+cd DockerCuick/
+tclsh ./install.tcl
+```
+
+After installation, you can remove the `src` directory if you really must, or
+you can leave it in place if you want to update the dependencies later. To
+update them, you just run the same script again. This will remove the `build`
+directory, `git pull` the source code and rebuild the needed packages.
+
+Don't remove the build directory. This directory contains the needed packages
+for the `dc` script. The script will refer to the `build` directory that is in
+the same directory, so you must always keep the `dc` script and the `build`
+directory in the same place.
+
+<details>
+
+<summary>
+<h4>Manual installation (requires root privileges)</h4>
+</summary>
+
+Prepare a directory to download, build and install some modules. The next
+sections will be executed in that directory.
+
+<h5>Install CriTcl</h5>
 
 Follow the installation guide
 [here](https://github.com/andreas-kupries/kettle/blob/master/embedded/md/doc/files/kettle_installer.md)
@@ -71,7 +103,7 @@ tclsh ./build.tcl install    # or ./build.tcl install
 cd ..
 ```
 
-**Install Kettle**
+<h5>Install Kettle</h5>
 
 Follow the installation guide
 [here](https://github.com/andreas-kupries/kettle/blob/master/embedded/md/doc/files/kettle_installer.md)
@@ -85,7 +117,7 @@ tclsh ./kettle ./build.tcl install
 cd ..
 ```
 
-**Install TclYAML**
+<h5>Install TclYAML</h5>
 
 Follow the installation guide
 [here](https://github.com/andreas-kupries/tclyaml.git) or try these quick steps
@@ -98,6 +130,8 @@ cd tclyaml
 tclsh ./build.tcl install    # or ./build.tcl install
 cd ..
 ```
+
+</details>
 
 ### Install the `dc` script
 
@@ -115,8 +149,8 @@ executable:
 chmod +x dc
 ```
 
-Alternatively, you can make a link to the `dc` script from within a folder that
-already is inside your `PATH`:
+Alternatively, you can make a link to the `dc` script from within a directory
+that already is inside your `PATH`:
 
 ```
 ln -s /folder/in/PATH/dc /git/repo/for/DockerCuick/dc

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Put the `dc` script in your shell path. On Bash, you can quickly do this by
 adding something like the following line in `~/.bashrc`:
 
 ```
-PATH=$HOME/Scripts/FolderWithTheDcScript:$PATH
+PATH=$HOME/git/repo/for/DockerCuick/:$PATH
 ```
 
 and don't forget to restart Bash :) . Also make sure that the script is

--- a/dc
+++ b/dc
@@ -13,7 +13,7 @@ set auto_path [ linsert $auto_path 0 $lib ]
 puts $auto_path
 
 package require Tcl 8.6
-package require tclyaml 0.5
+package require tclyaml 0.6
 
 # Constants
 

--- a/dc
+++ b/dc
@@ -1,5 +1,17 @@
 #!/bin/tclsh
 
+# Optionally use local "build" folder from the installation for finding the TclYAML package
+# Make sure that if this is started via a soft link, that the correct path is used: [info script] reports to be in the folder of the symlink instead of the original file.
+
+if { [ file type [ info script ] ] eq "link" } {
+  set script_path [ file dirname [ file join [ file dirname [ info script ] ] [ file readlink [ info script ] ] ] ]
+} {
+  set script_path [ file dirname [ file normalize [ info script ] ] ]
+}
+set lib [ file join $script_path build usr lib ]
+set auto_path [ linsert $auto_path 0 $lib ]
+puts $auto_path
+
 package require Tcl 8.6
 package require tclyaml 0.5
 
@@ -250,9 +262,9 @@ foreach subCommandWithOpts $subCommands {
 
   # Add local options to the subcommand, based on some conditions
 
-  if { [ llength $serviceParams ] eq 1 && $subCommand eq "logs" } {
-    set subCommandOpts [ string cat $subCommandOpts " --no-log-prefix" ]
-  }
+  #if { [ llength $serviceParams ] eq 1 && $subCommand eq "logs" } {
+  #  set subCommandOpts [ string cat $subCommandOpts " --no-log-prefix" ]
+  #}
 
   # Prepare a docker compose command and execute, forwarding stdin and stdout correctly
   # The extra `[list {*} ""]` is just for removing the redundant spaces

--- a/install.tcl
+++ b/install.tcl
@@ -1,0 +1,63 @@
+#!/bin/tclsh
+
+set script_path [ file dirname [ file normalize [ info script ] ] ]
+
+set src_directory [ file join $script_path src ]
+set build_directory [ file join $script_path build ]
+
+if { ! [ file exists $src_directory ] } {
+  puts "Creating source directory"
+  file mkdir $src_directory
+}
+if { [ file exists $build_directory ] } {
+  puts "Build directory already exists, removing it before re-installing or updating."
+  file delete -force $build_directory
+}
+puts "Creating build directory"
+file mkdir $build_directory
+
+cd $src_directory
+
+if { [ file exists [ file join $src_directory critcl ] ] } {
+  puts "CriTcl source already exists, updating"
+  cd [ file join $src_directory critcl ]
+  exec git pull 2>@stdout >@stdout <@stdin
+  cd $src_directory
+} {
+  puts "Pulling source for CriTcl"
+  exec git clone https://github.com/andreas-kupries/critcl.git 2>@stdout >@stdout <@stdin
+}
+if { [ file exists [ file join $src_directory kettle ] ] } {
+  puts "Kettle source already exists, updating"
+  cd [ file join $src_directory kettle ]
+  exec git pull 2>@stdout >@stdout <@stdin
+  cd $src_directory
+} {
+  puts "Pulling source for Kettle"
+  exec git clone https://github.com/andreas-kupries/kettle.git 2>@stdout >@stdout <@stdin
+}
+if { [ file exists [ file join $src_directory tclyaml ] ] } {
+  puts "TclYAML source already exists, updating"
+  cd [ file join $src_directory tclyaml ]
+  exec git pull 2>@stdout >@stdout <@stdin
+  cd $src_directory
+} {
+  puts "Pulling source for TclYAML"
+  exec git clone https://github.com/andreas-kupries/tclyaml.git 2>@stdout >@stdout <@stdin
+}
+
+puts "Installing CriTcl"
+cd [ file join $src_directory critcl ]
+exec tclsh ./build.tcl install --dest-dir $build_directory 2>@stdout >@stdout <@stdin
+
+puts "Installing Kettle"
+cd [ file join $src_directory kettle ]
+exec tclsh ./kettle --prefix [ file join $build_directory usr ] install 2>@stdout >@stdout <@stdin
+
+puts "Installing TclYAML"
+cd [ file join $src_directory tclyaml ]
+set ::env(TCLLIBPATH) [ file join $build_directory usr lib ]
+exec [ file join $build_directory usr bin kettle ] -f build.tcl --prefix [ file join $build_directory usr ] install 2>@stdout >@stdout <@stdin
+
+puts "Installation complete!"
+


### PR DESCRIPTION
An automatic install script will install dependencies in a local folder that will be used by the script. This does no longer require root privileges. A manual installation is still possible.