### PR TITLE
Use `@` to explicitly include all matching services

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,9 @@ service by using `+datab`, with a plus symbol at the start of the pattern,
 which matches the longest servicename `database-replicator`. A minus symbol
 will match the shortest servicename. A period will match the exact pattern:
 `.database` will only match `database` and will not match
-`database-replicator`.
+`database-replicator`. Use a `@` search modifier to explicitely keep all
+matches (this is completely redundant when searching, but can come in handy
+when managing services).
 
 **NOTE:** make sure to take a look at the "Reference" section below for "Search
 modifiers" for narrowing down your searches.
@@ -506,14 +508,16 @@ below show these options for the conditions.
 In some cases, your search pattern for subcommands or services might give more
 than one result. You could give more characters to your search pattern to
 narrow down the search, but you could also use modifiers to choose the
-shortest, longest, or exact match. These modifiers are the first character of
-your subcommand or servicename search pattern.
+shortest, longest, exact match, or even to explicitely include all matches.
+These modifiers are the first character of your subcommand or servicename
+search pattern.
 
-| Modifier | Result                  |
-| -------- | ----------------------- |
-| +        | Longest match possible  |
-| .        | Exact match             |
-| -        | Shortest match possible |
+| Modifier | Result                          |
+| -------- | ------------------------------- |
+| +        | Longest match possible          |
+| .        | Exact match                     |
+| -        | Shortest match possible         |
+| @        | Explicitely include all matches |
 
 ## Limitations
 

--- a/dc
+++ b/dc
@@ -66,6 +66,9 @@ proc matchInList { param paramList } {
     set param [ string range $param 1 end ]
     set matches [ lsearch -glob -inline -all $paramList "*$param*" ]
     lrange $matches 0 0
+  } elseif { $firstCharacter eq "@" } {
+    set param [ string range $param 1 end ]
+    lsearch -glob -inline -all $paramList "*$param*"
   } else {
     lsearch -glob -inline -all $paramList "*$param*"
   }
@@ -251,9 +254,11 @@ foreach subCommandWithOpts $subCommands {
 
   # Finding services that match params
 
-  set serviceParams [ lmap param $params {
+  set serviceParams {}
+  foreach param $params {
     set matches [ matchInList $param $serviceNames ]
-    if { [ llength $matches ] > 1 } {
+    set firstCharacter [ string range $param 0 0 ]
+    if { [ llength $matches ] > 1 && $firstCharacter ne "@" } {
       puts "ERROR: more than one service matches your pattern"
       puts "$param:"
       puts "  $matches"
@@ -264,8 +269,10 @@ foreach subCommandWithOpts $subCommands {
       # Quit the script
       return 1
     }
-    lindex $matches 0
-  } ]
+    # Append service names, expand with {*} to flatten the list
+    # Multiple services possible with @
+    lappend serviceParams {*}$matches
+  }
 
   # Add local options to the subcommand, based on some conditions
 


### PR DESCRIPTION
When using `@` as a search modifier, explicitly include all matches as service names in the final `docker compose` command. For example:

```
$>  dc d virt @data
docker compose down virtuoso database vendor-data-distribution
```

(note that the full command is now about 3 services, while there where only 2 service search patterns).